### PR TITLE
Modified activity_no_permission.xml

### DIFF
--- a/app/src/main/res/layout/activity_no_permission.xml
+++ b/app/src/main/res/layout/activity_no_permission.xml
@@ -71,6 +71,7 @@
         style="@style/Widget.AppCompat.Button.Borderless.Colored"
         android:layout_width="wrap_content"
         android:layout_height="40dp"
+		android:textColor="#000000"
         android:textSize="@dimen/text_size_button"
         android:layout_gravity="center_horizontal"
         android:background="@drawable/btn_aqua"


### PR DESCRIPTION
Hello,
I just noticed a color issue. The text color of the "GRANT PERMISSION" button is white, which causes insufficient color contrast and makes it very hard to read. Therefore, it should be changed to black.

Before：
![Before](https://github.com/user-attachments/assets/4abacd47-e9ff-480b-9a44-11e91deb94c8)

After：
![After](https://github.com/user-attachments/assets/5dc21a10-1ec7-4870-b4d3-31a7d33dba95)
