### PR TITLE
Disable file:// access flags on the WebBle WebView

### DIFF
--- a/app/src/main/java/cc/calliope/mini/ui/fragment/web/WebBleFragment.kt
+++ b/app/src/main/java/cc/calliope/mini/ui/fragment/web/WebBleFragment.kt
@@ -133,7 +133,13 @@ class WebBleFragment : Fragment() {
         with(webView.settings) {
             javaScriptEnabled = true
             domStorageEnabled = true
-            allowFileAccess = true
+            // pageUrl is always an https editor URL (see the default value
+            // assigned to `pageUrl` and the argument plumbing), so this
+            // WebView never legitimately needs file:// access. The
+            // AndroidBle bridge is exposed to whatever document loads here,
+            // so leaving these flags on would let a file:// page reach the
+            // BLE bridge.
+            allowFileAccess = false
             allowContentAccess = true
             cacheMode = WebSettings.LOAD_DEFAULT
             defaultTextEncodingName = "utf-8"
@@ -142,8 +148,8 @@ class WebBleFragment : Fragment() {
 
             mediaPlaybackRequiresUserGesture = false
             javaScriptCanOpenWindowsAutomatically = true
-            allowFileAccessFromFileURLs = true
-            allowUniversalAccessFromFileURLs = true
+            allowFileAccessFromFileURLs = false
+            allowUniversalAccessFromFileURLs = false
         }
         bridge = AndroidBleBridge(requireContext())
         webView.addJavascriptInterface(bridge, "AndroidBle")


### PR DESCRIPTION
Closes #46.

`WebBleFragment.onViewCreated` builds the editor WebView with all three `file://` access flags enabled while also attaching the `AndroidBle` JS bridge:

```kotlin
with(webView.settings) {
    javaScriptEnabled = true
    domStorageEnabled = true
    allowFileAccess = true
    ...
    allowFileAccessFromFileURLs = true
    allowUniversalAccessFromFileURLs = true
}
bridge = AndroidBleBridge(requireContext())
webView.addJavascriptInterface(bridge, "AndroidBle")
```

The WebView is then pointed at `pageUrl`, which is always an https editor URL (default `https://cardboard.lofirobot.com/control-calliope/`, plus makecode and python.calliope variants). None of those flows load `file://`, so the three flags only widen the surface that a stray file-URL load could use to reach the BLE bridge.

### Changes

Flip all three to `false`:

```kotlin
allowFileAccess = false
allowFileAccessFromFileURLs = false
allowUniversalAccessFromFileURLs = false
```

### Why this is safe

- `allowFileAccess = false` blocks `file://` URL loads but the `file:///android_asset/` scheme remains available on every supported Android version, so any bundled asset still loads.
- `allowFileAccessFromFileURLs = false` and `allowUniversalAccessFromFileURLs = false` only take effect if the main page is itself a `file://` document. Since the WebView never legitimately loads one, the change is a no-op for the editor flow.

On `minSdk 23` (the project setting) the two `FromFileURLs` flags default to `true`, so this PR is a tightening on every device the app supports, not a no-op only on newer Android.

`WebFragment` (the non-BLE editor fragment) is left untouched because it does not toggle any of these three flags.